### PR TITLE
[Fix] Firebase version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,11 +55,11 @@ xmlns:android="http://schemas.android.com/apk/res/android">
 		<source-file src="src/android/colors.xml" target-dir="res/values" />
 
 		<framework src="src/android/build.gradle" custom="true" type="gradleReference" />
-		<framework src="com.google.android.gms:play-services-tagmanager:+" />
-		<framework src="com.google.firebase:firebase-core:+" />
-		<framework src="com.google.firebase:firebase-messaging:+" />
-		<framework src="com.google.firebase:firebase-config:+" />
-		<framework src="com.google.firebase:firebase-perf:+" />
+		<framework src="com.google.android.gms:play-services-tagmanager:16.0.8" />
+		<framework src="com.google.firebase:firebase-core:16.0.8" />
+		<framework src="com.google.firebase:firebase-messaging:17.5.0" />
+		<framework src="com.google.firebase:firebase-config:16.4.1" />
+		<framework src="com.google.firebase:firebase-perf:16.2.4" />
 	</platform>
 
 	<platform name="ios">


### PR DESCRIPTION
# TODO

Android preprod failed to build : `The library com.google.android.gms:play-services-measurement-base is being requested by various other libraries at [[16.5.0,16.5.0], [16.4.0,16.4.0]], but resolves to 16.5.0. Disable the plugin and check your dependencies tree using ./gradlew :app:dependencies.`.

Found a response here : https://github.com/arnesson/cordova-plugin-firebase/issues/1057#issuecomment-490000068 and apply it to our fork.